### PR TITLE
Add extra fields

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -60,7 +60,7 @@ The following types are used for the fields in this specification.
 * `Integer` A 32-bit signed integer.
 * `Map` A data structure of key-value pairs where each key is unique. Also known as "dictionary", "hash".
   * In some fields we restrict the key-value types to specific types. Currently utilized restrictions are:
-    * <String, Array|Binary>: used by`atomProperties`, `bondProperties`, `groupProperties`, `chainProperties`, and `modelProperties`
+    * <String, Array|Binary>: used by `atomProperties`, `bondProperties`, `groupProperties`, `chainProperties`, and `modelProperties`
     * <String, String|Float|Integer|Map|Array|Binary>: used by `extraProperties`
 * `Array` A sequence of elements that have the same type.
 * `Binary` An array of unsigned 8-bit integer numbers representing binary data.

--- a/spec.md
+++ b/spec.md
@@ -1486,7 +1486,7 @@ data = {
 
 *Description*: A field meant to store information on specific bonds.  Must have the same length as [numBonds](#numbonds).
 
-*Convention key:value pairs*
+*Reserved key:value pairs*
 
 | Key                    | Value-description                                                             |
 |------------------------|-------------------------------------------------------------------------------|
@@ -1503,7 +1503,7 @@ data = {
 
 *Description*: A field meant to store information on specific atoms. Must have the same length as [numAtoms](#numatoms)
 
-*Convention key:value pairs*
+*Reserved key:value pairs*
 
 | Key                    | Value-description                                                             |
 |------------------------|-------------------------------------------------------------------------------|
@@ -1520,7 +1520,7 @@ data = {
 
 *Description*: A field meant to store information on specific groups. Must have the same length as [numGroups](#numgroups)
 
-*Convention key:value pairs*
+*Reserved key:value pairs*
 
 | Key                    | Value-description                                                             |
 |------------------------|-------------------------------------------------------------------------------|
@@ -1536,7 +1536,7 @@ data = {
 
 *Description*: A field meant to store information on specific chains. Must have the same length as [numChains](#numchains)
 
-*Convention key:value pairs*
+*Reserved key:value pairs*
 
 | Key                    | Value-description                                                             |
 |------------------------|-------------------------------------------------------------------------------|
@@ -1552,7 +1552,7 @@ data = {
 
 *Description*: A field meant to store information on specific models. Must have the same length as [numModels](#nummodels)
 
-*Convention key:value pairs*
+*Reserved key:value pairs*
 
 | Key                    | Value-description                                                             |
 |------------------------|-------------------------------------------------------------------------------|
@@ -1570,7 +1570,7 @@ data = {
 
 *Description*: A field meant to store any information at all.
 
-*Convention key:value pairs*
+*Reserved key:value pairs*
 
 | Key                   | Value-description                      |
 |-----------------------|----------------------------------------|

--- a/spec.md
+++ b/spec.md
@@ -404,12 +404,12 @@ The following table lists all top level fields, including their [type](#types) a
 | [chainNameList](#chainnamelist)             | [Binary](#types)    |          |
 | [groupsPerChain](#groupsperchain)           | [Array](#types)     |    Y     |
 | [chainsPerModel](#chainspermodel)           | [Array](#types)     |    Y     |
-| [extraProperties](#extraproperties)         | [Array](#types)     |          |
-| [bondProperties](#bondproperties)           | [Array](#types)     |          |
-| [atomProperties](#atomproperties)           | [Array](#types)     |          |
-| [groupProperties](#groupproperties)         | [Array](#types)     |          |
-| [chainProperties](#chainproperties)         | [Array](#types)     |          |
-| [modelProperties](#modelproperties)         | [Array](#types)     |          |
+| [bondProperties](#bondproperties)           | [Map](#types)       |          |
+| [atomProperties](#atomproperties)           | [Map](#types)       |          |
+| [groupProperties](#groupproperties)         | [Map](#types)       |          |
+| [chainProperties](#chainproperties)         | [Map](#types)       |          |
+| [modelProperties](#modelproperties)         | [Map](#types)       |          |
+| [extraProperties](#extraproperties)         | [Map](#types)       |          |
 
 
 ### Format data
@@ -919,124 +919,9 @@ The number of chains in a structure is equal to the length of the [groupsPerChai
 
 *Required field*
 
-# TODO MAP
 *Type*: [Array](#types) of [Integer](#types) numbers.
 
 *Description*: Array of the number of groups (aka residues) in each chain. The number of chains is thus equal to the length of the `groupsPerChain` field. In conjunction with `chainsPerModel`, the array allows looping over all chains:
-
-### Extra data
-
-The following are fields that are __not__ supplied by the *RCSB*, and are provided for applications to transfer application specific data along with the molecular data.
-
-The restrictions on each of the fields are __not__ enforced at decode-time and are simple conventions to help guide applications.
-
-| Name            | length-restrictions     | 
-|-----------------|-------------------------|
-| bondProperties  | length of numBonds      |
-| atomProperties  | length of numAtoms      |
-| groupProperties | length of numGroups     |
-| chainProperties | length of numChains     |
-| modelProperties | length of numModels     |
-| extraProperties | None                    |
-
-#### bondProperties
-
-*Optional field*
-
-*Type*: [Map](#types)
-
-*Description*: A field meant to store information on specific bonds.  Must have the same length as [numBonds](#numbonds).
-
-*Convention key:value pairs*
-
-| Key                 | Value-description                                                             |
-|---------------------|-------------------------------------------------------------------------------|
-| colorList           | color hex code                                                                |
-| transparancyList    | float (0-1)                                                                   |
-| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
-
-
-#### atomProperties
-
-*Optional field*
-
-*Type*: [Map](#types)
-
-*Description*: A field meant to store information on specific atoms. Must have the same length as [numAtoms](#numatoms)
-
-*Convention key:value pairs*
-
-| Key                 | Value-description                                                             |
-|---------------------|-------------------------------------------------------------------------------|
-| colorList           | color hex code                                                                |
-| transparancyList    | float (0-1)                                                                   |
-| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
-
-
-#### groupProperties
-
-*Optional field*
-
-*Type*: [Map](#types)
-
-*Description*: A field meant to store information on specific groups. Must have the same length as [numGroups](#numgroups)
-
-*Convention key:value pairs*
-
-| Key                 | Value-description                                                             |
-|---------------------|-------------------------------------------------------------------------------|
-| colorList           | color hex code                                                                |
-| transparancyList    | float (0-1)                                                                   |
-| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
-
-#### chainProperties
-
-*Optional field*
-
-*Type*: [Map](#types)
-
-*Description*: A field meant to store information on specific chains. Must have the same length as [numGroups](#numchains)
-
-*Convention key:value pairs*
-
-| Key                 | Value-description                                                             |
-|---------------------|-------------------------------------------------------------------------------|
-| colorList           | color hex code                                                                |
-| transparancyList    | float (0-1)                                                                   |
-| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
-
-#### modelProperties
-
-*Optional field*
-
-*Type*: [Map](#types)
-
-*Description*: A field meant to store information on specific models. Must have the same length as [numGroups](#nummodels)
-
-*Convention key:value pairs*
-
-| Key                 | Value-description                                                             |
-|---------------------|-------------------------------------------------------------------------------|
-| colorList           | color hex code                                                                |
-| transparancyList    | float (0-1)                                                                   |
-| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
-
-#### extraProperties
-
-*Optional field*
-
-*Type*: [Map](#types)
-
-*Description*: A field meant to store any information at all. There are no length restrictions associated with this field.  We
-encourage you to apply our encoding techniques to your application data to reduce file sizes!
-
-*Convention key:value pairs*
-
-| Key                   | Value-description                      |
-|-----------------------|----------------------------------------|
-| cameraPosition        | cartesian (x,y,z)                      |
-| cameraDirectionVector | cartesian vector [(x,y,z), (x,y,z)]    |
-
 
 ```Python
 # initialize index counters
@@ -1522,6 +1407,122 @@ Applying integer decoding with a divisor of `100` to create an array of 32-bit f
 ```JSON
 [ 1.00, 1.00, 1.00, 1.00, 0.50, 0.50 ]
 ```
+
+### Extra data
+
+The following are fields that are __not__ supplied by the *RCSB*, and are provided for applications to transfer non-molecular data along with the molecular data.
+
+The restrictions on each of the fields are __not__ enforced at decode-time and are simple conventions to help guide applications.
+
+| Name            | length-restrictions     | 
+|-----------------|-------------------------|
+| bondProperties  | length of numBonds      |
+| atomProperties  | length of numAtoms      |
+| groupProperties | length of numGroups     |
+| chainProperties | length of numChains     |
+| modelProperties | length of numModels     |
+| extraProperties | None                    |
+
+#### bondProperties
+
+*Optional field*
+
+*Type*: [Map](#types)
+
+*Description*: A field meant to store information on specific bonds.  Must have the same length as [numBonds](#numbonds).
+
+*Convention key:value pairs*
+
+| Key                 | Value-description                                                             |
+|---------------------|-------------------------------------------------------------------------------|
+| colorList           | color hex code                                                                |
+| transparancyList    | float (0-1)                                                                   |
+| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
+
+
+#### atomProperties
+
+*Optional field*
+
+*Type*: [Map](#types)
+
+*Description*: A field meant to store information on specific atoms. Must have the same length as [numAtoms](#numatoms)
+
+*Convention key:value pairs*
+
+| Key                 | Value-description                                                             |
+|---------------------|-------------------------------------------------------------------------------|
+| colorList           | color hex code                                                                |
+| transparancyList    | float (0-1)                                                                   |
+| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
+
+
+#### groupProperties
+
+*Optional field*
+
+*Type*: [Map](#types)
+
+*Description*: A field meant to store information on specific groups. Must have the same length as [numGroups](#numgroups)
+
+*Convention key:value pairs*
+
+| Key                 | Value-description                                                             |
+|---------------------|-------------------------------------------------------------------------------|
+| colorList           | color hex code                                                                |
+| transparancyList    | float (0-1)                                                                   |
+| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
+
+#### chainProperties
+
+*Optional field*
+
+*Type*: [Map](#types)
+
+*Description*: A field meant to store information on specific chains. Must have the same length as [numChains](#numchains)
+
+*Convention key:value pairs*
+
+| Key                 | Value-description                                                             |
+|---------------------|-------------------------------------------------------------------------------|
+| colorList           | color hex code                                                                |
+| transparancyList    | float (0-1)                                                                   |
+| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
+
+#### modelProperties
+
+*Optional field*
+
+*Type*: [Map](#types)
+
+*Description*: A field meant to store information on specific models. Must have the same length as [numModels](#nummodels)
+
+*Convention key:value pairs*
+
+| Key                 | Value-description                                                             |
+|---------------------|-------------------------------------------------------------------------------|
+| colorList           | color hex code                                                                |
+| transparancyList    | float (0-1)                                                                   |
+| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
+| rmsdList            | list[floats]                                                                  |
+| gdtList             | list[floats]                                                                  |
+
+#### extraProperties
+
+*Optional field*
+
+*Type*: [Map](#types)
+
+*Description*: A field meant to store any information at all. There are no length restrictions associated with this field.  We
+encourage you to apply our encoding techniques to your application data to reduce file sizes!
+
+*Convention key:value pairs*
+
+| Key                   | Value-description                      |
+|-----------------------|----------------------------------------|
+| cameraPosition        | cartesian (x,y,z)                      |
+| cameraDirectionVector | cartesian vector [(x,y,z), (x,y,z)]    |
+
 
 
 ## Traversal

--- a/spec.md
+++ b/spec.md
@@ -1672,7 +1672,28 @@ data = {
 
 *Type*: [Map<String, String|Float|Integer|Map|Array|Binary>](#types)
 
-*Description*: A field meant to store any information at all.
+*Description*: A field meant to store any information at all.  There are no restrictions on second-level data structures such as Map<String, Map>.
+example
+```python
+
+# Good!
+data = {
+  "mmtfVersion": "1.1",
+  ...
+  "extraProperties": {
+    "pymol_bondTypes": {0: "metal", 1: "single", 2: "double", 3: "triple", 4: "aromatic"},
+  }
+}
+
+# Bad!
+data = {
+  "mmtfVersion": "1.1",
+  ...
+  "extraProperties": {
+    1: {0: "false", 1: "true", 2: "true", 3: "false", 4: "false"},
+  }
+}
+```
 
 *Reserved key:value pairs*
 

--- a/spec.md
+++ b/spec.md
@@ -1538,7 +1538,7 @@ The restrictions on each of the lengths of the values in these fields are __not_
 
 Example
 
-```
+```python
 data = {
   "mmtfVersion": "1.1",
   "numAtoms": 999,
@@ -1549,9 +1549,6 @@ data = {
   "yCoordList": [5.6, 7.8, ...],
   "zCoordList": [9.0, 1.2, ...],
   ...
-  "structureProperties": {
-    "foo_id": "ABC",
-  },
   "modelProperties": {
     # lists have len numModels=2
     "foo_rmsdList": [0.5, 0.8],
@@ -1579,7 +1576,8 @@ data = {
     "pymol_bondTypeList": [1, 1, 1, 4, 4, 4, 4, 4, 4, 1, ...],
   },
   "extraProperties": {
-    "pymol_bondTypes": {0: "metal", 1: "single", 2: "double", 3: "triple", 4: "aromatic"}
+    "pymol_bondTypes": {0: "metal", 1: "single", 2: "double", 3: "triple", 4: "aromatic"},
+    "foo_id": "ABC",
   }
 }
 ```

--- a/spec.md
+++ b/spec.md
@@ -59,6 +59,9 @@ The following types are used for the fields in this specification.
 * `Float` A 32-bit floating-point number.
 * `Integer` A 32-bit signed integer.
 * `Map` A data structure of key-value pairs where each key is unique. Also known as "dictionary", "hash".
+  * In some fields we restrict the key-value types to specific types. Currently utilized restrictions are:
+    * <String, Array|Binary>: used by`atomProperties`, `bondProperties`, `groupProperties`, `chainProperties`, and `modelProperties`
+    * <String, String|Float|Integer|Map|Array|Binary>: used by `extraProperties`
 * `Array` A sequence of elements that have the same type.
 * `Binary` An array of unsigned 8-bit integer numbers representing binary data.
 
@@ -364,53 +367,53 @@ The indices can then be used to reference the values as often as needed:
 
 The following table lists all top level fields, including their [type](#types) and whether they are required or optional. The top-level fields themselves are stores as a `Map`.
 
-| Name                                        | Type                | Required |
-|---------------------------------------------|---------------------|:--------:|
-| [mmtfVersion](#mmtfversion)                 | [String](#types)    |    Y     |
-| [mmtfProducer](#mmtfproducer)               | [String](#types)    |    Y     |
-| [unitCell](#unitcell)                       | [Array](#types)     |          |
-| [spaceGroup](#spacegroup)                   | [String](#types)    |          |
-| [structureId](#structureid)                 | [String](#types)    |          |
-| [title](#title)                             | [String](#types)    |          |
-| [depositionDate](#depositiondate)           | [String](#types)    |          |
-| [releaseDate](#releasedate)                 | [String](#types)    |          |
-| [ncsOperatorList](#ncsoperatorlist)         | [Array](#types)     |          |
-| [bioAssemblyList](#bioassemblylist)         | [Array](#types)     |          |
-| [entityList](#entitylist)                   | [Array](#types)     |          |
-| [experimentalMethods](#experimentalmethods) | [Array](#types)     |          |
-| [resolution](#resolution)                   | [Float](#types)     |          |
-| [rFree](#rfree)                             | [Float](#types)     |          |
-| [rWork](#rwork)                             | [Float](#types)     |          |
-| [numBonds](#numbonds)                       | [Integer](#types)   |    Y     |
-| [numAtoms](#numatoms)                       | [Integer](#types)   |    Y     |
-| [numGroups](#numgroups)                     | [Integer](#types)   |    Y     |
-| [numChains](#numchains)                     | [Integer](#types)   |    Y     |
-| [numModels](#nummodels)                     | [Integer](#types)   |    Y     |
-| [groupList](#grouplist)                     | [Array](#types)     |    Y     |
-| [bondAtomList](#bondatomlist)               | [Binary](#types)    |          |
-| [bondOrderList](#bondorderlist)             | [Binary](#types)    |          |
-| [xCoordList](#xcoordlist)                   | [Binary](#types)    |    Y     |
-| [yCoordList](#ycoordlist)                   | [Binary](#types)    |    Y     |
-| [zCoordList](#zcoordlist)                   | [Binary](#types)    |    Y     |
-| [bFactorList](#bfactorlist)                 | [Binary](#types)    |          |
-| [atomIdList](#atomidlist)                   | [Binary](#types)    |          |
-| [altLocList](#altloclist)                   | [Binary](#types)    |          |
-| [occupancyList](#occupancylist)             | [Binary](#types)    |          |
-| [groupIdList](#groupidlist)                 | [Binary](#types)    |    Y     |
-| [groupTypeList](#grouptypelist)             | [Binary](#types)    |    Y     |
-| [secStructList](#secstructlist)             | [Binary](#types)    |          |
-| [insCodeList](#inscodelist)                 | [Binary](#types)    |          |
-| [sequenceIndexList](#sequenceindexlist)     | [Binary](#types)    |          |
-| [chainIdList](#chainidlist)                 | [Binary](#types)    |    Y     |
-| [chainNameList](#chainnamelist)             | [Binary](#types)    |          |
-| [groupsPerChain](#groupsperchain)           | [Array](#types)     |    Y     |
-| [chainsPerModel](#chainspermodel)           | [Array](#types)     |    Y     |
-| [bondProperties](#bondproperties)           | [Map](#types)       |          |
-| [atomProperties](#atomproperties)           | [Map](#types)       |          |
-| [groupProperties](#groupproperties)         | [Map](#types)       |          |
-| [chainProperties](#chainproperties)         | [Map](#types)       |          |
-| [modelProperties](#modelproperties)         | [Map](#types)       |          |
-| [extraProperties](#extraproperties)         | [Map](#types)       |          |
+| Name                                        | Type                                                               | Required |
+|---------------------------------------------|--------------------------------------------------------------------|:--------:|
+| [mmtfVersion](#mmtfversion)                 | [String](#types)                                                   |    Y     |
+| [mmtfProducer](#mmtfproducer)               | [String](#types)                                                   |    Y     |
+| [unitCell](#unitcell)                       | [Array](#types)                                                    |          |
+| [spaceGroup](#spacegroup)                   | [String](#types)                                                   |          |
+| [structureId](#structureid)                 | [String](#types)                                                   |          |
+| [title](#title)                             | [String](#types)                                                   |          |
+| [depositionDate](#depositiondate)           | [String](#types)                                                   |          |
+| [releaseDate](#releasedate)                 | [String](#types)                                                   |          |
+| [ncsOperatorList](#ncsoperatorlist)         | [Array](#types)                                                    |          |
+| [bioAssemblyList](#bioassemblylist)         | [Array](#types)                                                    |          |
+| [entityList](#entitylist)                   | [Array](#types)                                                    |          |
+| [experimentalMethods](#experimentalmethods) | [Array](#types)                                                    |          |
+| [resolution](#resolution)                   | [Float](#types)                                                    |          |
+| [rFree](#rfree)                             | [Float](#types)                                                    |          |
+| [rWork](#rwork)                             | [Float](#types)                                                    |          |
+| [numBonds](#numbonds)                       | [Integer](#types)                                                  |    Y     |
+| [numAtoms](#numatoms)                       | [Integer](#types)                                                  |    Y     |
+| [numGroups](#numgroups)                     | [Integer](#types)                                                  |    Y     |
+| [numChains](#numchains)                     | [Integer](#types)                                                  |    Y     |
+| [numModels](#nummodels)                     | [Integer](#types)                                                  |    Y     |
+| [groupList](#grouplist)                     | [Array](#types)                                                    |    Y     |
+| [bondAtomList](#bondatomlist)               | [Binary](#types)                                                   |          |
+| [bondOrderList](#bondorderlist)             | [Binary](#types)                                                   |          |
+| [xCoordList](#xcoordlist)                   | [Binary](#types)                                                   |    Y     |
+| [yCoordList](#ycoordlist)                   | [Binary](#types)                                                   |    Y     |
+| [zCoordList](#zcoordlist)                   | [Binary](#types)                                                   |    Y     |
+| [bFactorList](#bfactorlist)                 | [Binary](#types)                                                   |          |
+| [atomIdList](#atomidlist)                   | [Binary](#types)                                                   |          |
+| [altLocList](#altloclist)                   | [Binary](#types)                                                   |          |
+| [occupancyList](#occupancylist)             | [Binary](#types)                                                   |          |
+| [groupIdList](#groupidlist)                 | [Binary](#types)                                                   |    Y     |
+| [groupTypeList](#grouptypelist)             | [Binary](#types)                                                   |    Y     |
+| [secStructList](#secstructlist)             | [Binary](#types)                                                   |          |
+| [insCodeList](#inscodelist)                 | [Binary](#types)                                                   |          |
+| [sequenceIndexList](#sequenceindexlist)     | [Binary](#types)                                                   |          |
+| [chainIdList](#chainidlist)                 | [Binary](#types)                                                   |    Y     |
+| [chainNameList](#chainnamelist)             | [Binary](#types)                                                   |          |
+| [groupsPerChain](#groupsperchain)           | [Array](#types)                                                    |    Y     |
+| [chainsPerModel](#chainspermodel)           | [Array](#types)                                                    |    Y     |
+| [bondProperties](#bondproperties)           | [Map<String, Array|Binary>](#types)                                |          |
+| [atomProperties](#atomproperties)           | [Map<String, Array|Binary>](#types)                                |          |
+| [groupProperties](#groupproperties)         | [Map<String, Array|Binary>](#types)                                |          |
+| [chainProperties](#chainproperties)         | [Map<String, Array|Binary>](#types)                                |          |
+| [modelProperties](#modelproperties)         | [Map<String, Array|Binary>](#types)                                |          |
+| [extraProperties](#extraproperties)         | [Map<String, String|Float|Integer|Map|Array|Binary>](#types)       |          |
 
 
 ### Format data
@@ -1482,7 +1485,7 @@ data = {
 
 *Optional field*
 
-*Type*: [Map](#types)
+*Type*: [Map<String, Array|Binary>](#types)
 
 *Description*: A field meant to store information on specific bonds.  Must have the same length as [numBonds](#numbonds).
 
@@ -1499,7 +1502,7 @@ data = {
 
 *Optional field*
 
-*Type*: [Map](#types)
+*Type*: [Map<String, Array|Binary>](#types)
 
 *Description*: A field meant to store information on specific atoms. Must have the same length as [numAtoms](#numatoms)
 
@@ -1516,7 +1519,7 @@ data = {
 
 *Optional field*
 
-*Type*: [Map](#types)
+*Type*: [Map<String, Array|Binary>](#types)
 
 *Description*: A field meant to store information on specific groups. Must have the same length as [numGroups](#numgroups)
 
@@ -1532,7 +1535,7 @@ data = {
 
 *Optional field*
 
-*Type*: [Map](#types)
+*Type*: [Map<String, Array|Binary>](#types)
 
 *Description*: A field meant to store information on specific chains. Must have the same length as [numChains](#numchains)
 
@@ -1548,7 +1551,7 @@ data = {
 
 *Optional field*
 
-*Type*: [Map](#types)
+*Type*: [Map<String, Array|Binary>](#types)
 
 *Description*: A field meant to store information on specific models. Must have the same length as [numModels](#nummodels)
 
@@ -1566,7 +1569,7 @@ data = {
 
 *Optional field*
 
-*Type*: [Map](#types)
+*Type*: [Map<String, String|Float|Integer|Map|Array|Binary>](#types)
 
 *Description*: A field meant to store any information at all.
 

--- a/spec.md
+++ b/spec.md
@@ -1520,6 +1520,9 @@ As mentioned in [Types](#types) in some fields we restrict the key-value types t
 * <String, String|Float|Integer|Map|Array|Binary>
   * `extraProperties`
 
+For each of the fields above, we do reserve some key-value pair formats to help ensure cross-application-compatibility.  If you feel
+a certain key-value pair should be reserved and made a part of the spec, please let us know!  
+
 We encourage you to apply our encoding techniques to your application data to reduce file sizes!
 
 The restrictions on each of the lengths of the values in these fields are __not__ enforced at decode-time but are reserved to help guide applications.

--- a/spec.md
+++ b/spec.md
@@ -949,11 +949,11 @@ The restrictions on each of the fields are __not__ enforced at decode-time and a
 
 *Convention key:value pairs*
 
-| Key                 | Value-description |
-|---------------------|-------------------|
-| colorList           | color hex code    |
-| transparancyList    | float (0-100)     |
-| representation type | ('    |
+| Key                 | Value-description                                                             |
+|---------------------|-------------------------------------------------------------------------------|
+| colorList           | color hex code                                                                |
+| transparancyList    | float (0-1)                                                                   |
+| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
 
 
 #### atomProperties
@@ -966,9 +966,11 @@ The restrictions on each of the fields are __not__ enforced at decode-time and a
 
 *Convention key:value pairs*
 
-| Key       | Value-description |
-|-----------|-------------------|
-| colorList | color hex code    |
+| Key                 | Value-description                                                             |
+|---------------------|-------------------------------------------------------------------------------|
+| colorList           | color hex code                                                                |
+| transparancyList    | float (0-1)                                                                   |
+| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
 
 
 #### groupProperties
@@ -981,9 +983,11 @@ The restrictions on each of the fields are __not__ enforced at decode-time and a
 
 *Convention key:value pairs*
 
-| Key       | Value-description |
-|-----------|-------------------|
-| colorList | color hex code    |
+| Key                 | Value-description                                                             |
+|---------------------|-------------------------------------------------------------------------------|
+| colorList           | color hex code                                                                |
+| transparancyList    | float (0-1)                                                                   |
+| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
 
 #### chainProperties
 
@@ -995,9 +999,11 @@ The restrictions on each of the fields are __not__ enforced at decode-time and a
 
 *Convention key:value pairs*
 
-| Key       | Value-description |
-|-----------|-------------------|
-| colorList | color hex code    |
+| Key                 | Value-description                                                             |
+|---------------------|-------------------------------------------------------------------------------|
+| colorList           | color hex code                                                                |
+| transparancyList    | float (0-1)                                                                   |
+| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
 
 #### modelProperties
 
@@ -1009,9 +1015,11 @@ The restrictions on each of the fields are __not__ enforced at decode-time and a
 
 *Convention key:value pairs*
 
-| Key       | Value-description |
-|-----------|-------------------|
-| colorList | color hex code    |
+| Key                 | Value-description                                                             |
+|---------------------|-------------------------------------------------------------------------------|
+| colorList           | color hex code                                                                |
+| transparancyList    | float (0-1)                                                                   |
+| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
 
 #### extraProperties
 
@@ -1024,10 +1032,10 @@ encourage you to apply our encoding techniques to your application data to reduc
 
 *Convention key:value pairs*
 
-| Key       | Value-description |
-|-----------|-------------------|
-| colorList | color hex code    |
-
+| Key                   | Value-description                      |
+|-----------------------|----------------------------------------|
+| cameraPosition        | cartesian (x,y,z)                      |
+| cameraDirectionVector | cartesian vector [(x,y,z), (x,y,z)]    |
 
 
 ```Python

--- a/spec.md
+++ b/spec.md
@@ -408,12 +408,12 @@ The following table lists all top level fields, including their [type](#types) a
 | [chainNameList](#chainnamelist)             | [Binary](#types)                                                   |          |
 | [groupsPerChain](#groupsperchain)           | [Array](#types)                                                    |    Y     |
 | [chainsPerModel](#chainspermodel)           | [Array](#types)                                                    |    Y     |
-| [bondProperties](#bondproperties)           | [Map<String, Array|Binary>](#types)                                |          |
-| [atomProperties](#atomproperties)           | [Map<String, Array|Binary>](#types)                                |          |
-| [groupProperties](#groupproperties)         | [Map<String, Array|Binary>](#types)                                |          |
-| [chainProperties](#chainproperties)         | [Map<String, Array|Binary>](#types)                                |          |
-| [modelProperties](#modelproperties)         | [Map<String, Array|Binary>](#types)                                |          |
-| [extraProperties](#extraproperties)         | [Map<String, String|Float|Integer|Map|Array|Binary>](#types)       |          |
+| [bondProperties](#bondproperties)           | [Map<String, Array\|Binary>](#types)                               |          |
+| [atomProperties](#atomproperties)           | [Map<String, Array\|Binary>](#types)                               |          |
+| [groupProperties](#groupproperties)         | [Map<String, Array\|Binary>](#types)                               |          |
+| [chainProperties](#chainproperties)         | [Map<String, Array\|Binary>](#types)                               |          |
+| [modelProperties](#modelproperties)         | [Map<String, Array\|Binary>](#types)                               |          |
+| [extraProperties](#extraproperties)         | [Map<String, String\|Float\|Integer\|Map\|Array\|Binary>](#types)  |          |
 
 
 ### Format data
@@ -1435,7 +1435,7 @@ The restrictions on each of the lengths of the values in these fields are __not_
 
 Example
 
-```JSON
+```
 data = {
   "mmtfVersion": "1.1",
   "numAtoms": 999,

--- a/spec.md
+++ b/spec.md
@@ -1672,11 +1672,14 @@ data = {
 
 *Type*: [Map<String, String|Float|Integer|Map|Array|Binary>](#types)
 
-*Description*: A field meant to store any information at all.  There are no restrictions on second-level data structures such as Map<String, Map>.
-example
+*Description*: A field meant to store any information at all.  There are no restrictions on second level data structures like the inner Map in
+Map<String, Map>.  
+
+Example:
+
 ```python
 
-# Good!
+# Ok!
 data = {
   "mmtfVersion": "1.1",
   ...

--- a/spec.md
+++ b/spec.md
@@ -404,6 +404,12 @@ The following table lists all top level fields, including their [type](#types) a
 | [chainNameList](#chainnamelist)             | [Binary](#types)    |          |
 | [groupsPerChain](#groupsperchain)           | [Array](#types)     |    Y     |
 | [chainsPerModel](#chainspermodel)           | [Array](#types)     |    Y     |
+| [extraProperties](#extraproperties)         | [Array](#types)     |          |
+| [bondProperties](#bondproperties)           | [Array](#types)     |          |
+| [atomProperties](#atomproperties)           | [Array](#types)     |          |
+| [groupProperties](#groupproperties)         | [Array](#types)     |          |
+| [chainProperties](#chainproperties)         | [Array](#types)     |          |
+| [modelProperties](#modelproperties)         | [Array](#types)     |          |
 
 
 ### Format data
@@ -913,9 +919,116 @@ The number of chains in a structure is equal to the length of the [groupsPerChai
 
 *Required field*
 
+# TODO MAP
 *Type*: [Array](#types) of [Integer](#types) numbers.
 
 *Description*: Array of the number of groups (aka residues) in each chain. The number of chains is thus equal to the length of the `groupsPerChain` field. In conjunction with `chainsPerModel`, the array allows looping over all chains:
+
+### Extra data
+
+The following are fields that are __not__ supplied by the *RCSB*, and are provided for applications to transfer application specific data along with the molecular data.
+
+The restrictions on each of the fields are __not__ enforced at decode-time and are simple conventions to help guide applications.
+
+| Name            | length-restrictions     | 
+|-----------------|-------------------------|
+| bondProperties  | length of numBonds      |
+| atomProperties  | length of numAtoms      |
+| groupProperties | length of numGroups     |
+| chainProperties | length of numChains     |
+| modelProperties | length of numModels     |
+| extraProperties | None                    |
+
+#### bondProperties
+
+*Optional field*
+
+*Type*: [Map](#types)
+
+*Description*: A field meant to store information on specific bonds.  Must have the same length as [numBonds](#numbonds).
+
+*Convention key:value pairs*
+
+| Key                 | Value-description |
+|---------------------|-------------------|
+| colorList           | color hex code    |
+| transparancyList    | float (0-100)     |
+| representation type | ('    |
+
+
+#### atomProperties
+
+*Optional field*
+
+*Type*: [Map](#types)
+
+*Description*: A field meant to store information on specific atoms. Must have the same length as [numAtoms](#numatoms)
+
+*Convention key:value pairs*
+
+| Key       | Value-description |
+|-----------|-------------------|
+| colorList | color hex code    |
+
+
+#### groupProperties
+
+*Optional field*
+
+*Type*: [Map](#types)
+
+*Description*: A field meant to store information on specific groups. Must have the same length as [numGroups](#numgroups)
+
+*Convention key:value pairs*
+
+| Key       | Value-description |
+|-----------|-------------------|
+| colorList | color hex code    |
+
+#### chainProperties
+
+*Optional field*
+
+*Type*: [Map](#types)
+
+*Description*: A field meant to store information on specific chains. Must have the same length as [numGroups](#numchains)
+
+*Convention key:value pairs*
+
+| Key       | Value-description |
+|-----------|-------------------|
+| colorList | color hex code    |
+
+#### modelProperties
+
+*Optional field*
+
+*Type*: [Map](#types)
+
+*Description*: A field meant to store information on specific models. Must have the same length as [numGroups](#nummodels)
+
+*Convention key:value pairs*
+
+| Key       | Value-description |
+|-----------|-------------------|
+| colorList | color hex code    |
+
+#### extraProperties
+
+*Optional field*
+
+*Type*: [Map](#types)
+
+*Description*: A field meant to store any information at all. There are no length restrictions associated with this field.  We
+encourage you to apply our encoding techniques to your application data to reduce file sizes!
+
+*Convention key:value pairs*
+
+| Key       | Value-description |
+|-----------|-------------------|
+| colorList | color hex code    |
+
+
 
 ```Python
 # initialize index counters

--- a/spec.md
+++ b/spec.md
@@ -23,6 +23,7 @@ The **m**acro**m**olecular **t**ransmission **f**ormat (MMTF) is a binary encodi
     * [Chain data](#chain-data)
     * [Group data](#group-data)
     * [Atom data](#atom-data)
+    * [Extra data](#extra-data)
 * [Traversal](#traversal)
 
 
@@ -1412,7 +1413,13 @@ Applying integer decoding with a divisor of `100` to create an array of 32-bit f
 
 The following are fields that are __not__ supplied by the *RCSB*, and are provided for applications to transfer non-molecular data along with the molecular data.
 
-The restrictions on each of the fields are __not__ enforced at decode-time and are simple conventions to help guide applications.
+Each field is a [map](#types), and there are 6 possible fields `bondProperties`, `atomProperties`, `groupProperties`, `chainProperties`,
+`modelProperties`, and `extraProperties`.  The first 5 fields are restricted to holding data that is relevant to the field's prefix, while
+any other data can be stored in the `extraProperties` field.
+
+We encourage you to apply our encoding techniques to your application data to reduce file sizes!
+
+The restrictions on each of the lengths of the values in these fields are __not__ enforced at decode-time but are reserved to help guide applications.
 
 | Name            | length-restrictions     | 
 |-----------------|-------------------------|
@@ -1422,6 +1429,54 @@ The restrictions on each of the fields are __not__ enforced at decode-time and a
 | chainProperties | length of numChains     |
 | modelProperties | length of numModels     |
 | extraProperties | None                    |
+
+Example
+
+```JSON
+data = {
+  "mmtfVersion": "1.1",
+  "numAtoms": 999,
+  "numModels": 2,
+  "numChains": 4,
+  ...
+  "xCoordList": [1.2, 3.4, ...],
+  "yCoordList": [5.6, 7.8, ...],
+  "zCoordList": [9.0, 1.2, ...],
+  ...
+  "structureProperties": {
+    "foo_id": "ABC",
+  },
+  "modelProperties": {
+    # lists have len numModels=2
+    "foo_rmsdList": [0.5, 0.8],
+    "foo_scoreList": [1.2, 3.4],
+  },
+  "chainProperties": {
+    # lists have len numChains=4
+    "foo_uniprotIdList": ["HBB_HUMAN", "HBA_HUMAN", "HBB_HUMAN", "HBA_HUMAN"],
+    "foo_chainColorList": [0xFF0000, 0x00FF00, 0xFF0000, 0x00FF00],
+  },
+  "groupProperties": {
+    # lists have len numGroups
+    "stride_secStructList": [7, 7, 7, ...],
+    "sst_secStructList": [7, 7, 7, ...],
+  },
+  "atomProperties": {
+    # lists have len numAtoms=999
+    "pymol_colorList": [1, 2, 3, ...],
+    "pymol_repsList": [1, 1, 1, ...],
+    "apbs_chargeList": [0.1, -0.4, 0.7, ...],
+    "apbs_radiusList": [1.2, 1.8, 1.5, ...],
+  },
+  "bondProperties": {
+    # lists have len numBonds
+    "pymol_bondTypeList": [1, 1, 1, 4, 4, 4, 4, 4, 4, 1, ...],
+  },
+  "extraProperties": {
+    "pymol_bondTypes": {0: "metal", 1: "single", 2: "double", 3: "triple", 4: "aromatic"}
+  }
+}
+```
 
 #### bondProperties
 
@@ -1513,8 +1568,7 @@ The restrictions on each of the fields are __not__ enforced at decode-time and a
 
 *Type*: [Map](#types)
 
-*Description*: A field meant to store any information at all. There are no length restrictions associated with this field.  We
-encourage you to apply our encoding techniques to your application data to reduce file sizes!
+*Description*: A field meant to store any information at all.
 
 *Convention key:value pairs*
 
@@ -1522,7 +1576,6 @@ encourage you to apply our encoding techniques to your application data to reduc
 |-----------------------|----------------------------------------|
 | cameraPosition        | cartesian (x,y,z)                      |
 | cameraDirectionVector | cartesian vector [(x,y,z), (x,y,z)]    |
-
 
 
 ## Traversal

--- a/spec.md
+++ b/spec.md
@@ -1433,11 +1433,11 @@ The restrictions on each of the fields are __not__ enforced at decode-time and a
 
 *Convention key:value pairs*
 
-| Key                 | Value-description                                                             |
-|---------------------|-------------------------------------------------------------------------------|
-| colorList           | color hex code                                                                |
-| transparancyList    | float (0-1)                                                                   |
-| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
+| Key                    | Value-description                                                             |
+|------------------------|-------------------------------------------------------------------------------|
+| colorList              | color hex code                                                                |
+| transparancyList       | float (0-1)                                                                   |
+| representationTypeList | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
 
 
 #### atomProperties
@@ -1450,11 +1450,11 @@ The restrictions on each of the fields are __not__ enforced at decode-time and a
 
 *Convention key:value pairs*
 
-| Key                 | Value-description                                                             |
-|---------------------|-------------------------------------------------------------------------------|
-| colorList           | color hex code                                                                |
-| transparancyList    | float (0-1)                                                                   |
-| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
+| Key                    | Value-description                                                             |
+|------------------------|-------------------------------------------------------------------------------|
+| colorList              | color hex code                                                                |
+| transparancyList       | float (0-1)                                                                   |
+| representationTypeList | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
 
 
 #### groupProperties
@@ -1467,11 +1467,11 @@ The restrictions on each of the fields are __not__ enforced at decode-time and a
 
 *Convention key:value pairs*
 
-| Key                 | Value-description                                                             |
-|---------------------|-------------------------------------------------------------------------------|
-| colorList           | color hex code                                                                |
-| transparancyList    | float (0-1)                                                                   |
-| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
+| Key                    | Value-description                                                             |
+|------------------------|-------------------------------------------------------------------------------|
+| colorList              | color hex code                                                                |
+| transparancyList       | float (0-1)                                                                   |
+| representationTypeList | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
 
 #### chainProperties
 
@@ -1483,11 +1483,11 @@ The restrictions on each of the fields are __not__ enforced at decode-time and a
 
 *Convention key:value pairs*
 
-| Key                 | Value-description                                                             |
-|---------------------|-------------------------------------------------------------------------------|
-| colorList           | color hex code                                                                |
-| transparancyList    | float (0-1)                                                                   |
-| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
+| Key                    | Value-description                                                             |
+|------------------------|-------------------------------------------------------------------------------|
+| colorList              | color hex code                                                                |
+| transparancyList       | float (0-1)                                                                   |
+| representationTypeList | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
 
 #### modelProperties
 
@@ -1499,13 +1499,13 @@ The restrictions on each of the fields are __not__ enforced at decode-time and a
 
 *Convention key:value pairs*
 
-| Key                 | Value-description                                                             |
-|---------------------|-------------------------------------------------------------------------------|
-| colorList           | color hex code                                                                |
-| transparancyList    | float (0-1)                                                                   |
-| representation type | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
-| rmsdList            | list[floats]                                                                  |
-| gdtList             | list[floats]                                                                  |
+| Key                    | Value-description                                                             |
+|------------------------|-------------------------------------------------------------------------------|
+| colorList              | color hex code                                                                |
+| transparancyList       | float (0-1)                                                                   |
+| representationTypeList | (0: "lines", 1: "spheres", 2: "surface", 3: "ball and stick", 4: "cartoon")   |
+| rmsdList               | list[floats]                                                                  |
+| gdtList                | list[floats]                                                                  |
 
 #### extraProperties
 

--- a/spec.md
+++ b/spec.md
@@ -1418,7 +1418,17 @@ The following are fields that are __not__ supplied by the *RCSB*, and are provid
 
 Each field is a [map](#types), and there are 6 possible fields `bondProperties`, `atomProperties`, `groupProperties`, `chainProperties`,
 `modelProperties`, and `extraProperties`.  The first 5 fields are restricted to holding data that is relevant to the field's prefix, while
-any other data can be stored in the `extraProperties` field.
+any other data can be stored in the `extraProperties` field.  
+
+As mentioned in [Types](#types) in some fields we restrict the key-value types to specific types. The current type format the sepc follows is:
+* <String, Array|Binary>
+  * `atomProperties`
+  * `bondProperties`
+  * `groupProperties`
+  * `chainProperties`
+  * `modelProperties`
+* <String, String|Float|Integer|Map|Array|Binary>
+  * `extraProperties`
 
 We encourage you to apply our encoding techniques to your application data to reduce file sizes!
 


### PR DESCRIPTION
This PR gives applications/users places to store their own data that's associate with their mmtf files.

Up for discussion:
Any `Convention key:value pairs` that you would like to see added.
Any `Convention` encode types you'd like to add
Do you like the format?

Other conventions to think about adding:

- specific colors for different representations

If you are interested there is already a working implementation of this in:
https://github.com/danpf/mmtf-cpp/tree/rcsb_extraData

This is meant to clear up issue:
https://github.com/rcsb/mmtf/issues/32